### PR TITLE
Use DEVELOPER_DIR instead of SYSTEM_APPS_DIR

### DIFF
--- a/Polychromatic.xcodeproj/project.pbxproj
+++ b/Polychromatic.xcodeproj/project.pbxproj
@@ -361,8 +361,8 @@
 				DSTROOT = "$(HOME)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(DEVELOPER_DIR)/../Frameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Polychromatic/Polychromatic-Prefix.pch";
@@ -386,8 +386,8 @@
 				DSTROOT = "$(HOME)";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/Frameworks",
-					"$(SYSTEM_APPS_DIR)/Xcode.app/Contents/SharedFrameworks",
+					"$(DEVELOPER_DIR)/../Frameworks",
+					"$(DEVELOPER_DIR)/../SharedFrameworks",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Polychromatic/Polychromatic-Prefix.pch";


### PR DESCRIPTION
This fixes compilation if Xcode was renamed.

I have 3 copies of Xcode: Xcode4.app, Xcode5.app and Xcode51.app. Polychromatic would not compile because of the hardcoded `Xcode.app` string.
