### PR TITLE
Add compatibility strings for XCode 6.2 and 6.3

### DIFF
--- a/Polychromatic/Polychromatic-Info.plist
+++ b/Polychromatic/Polychromatic-Info.plist
@@ -31,6 +31,8 @@
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>992275C1-432A-4CF7-B659-D84ED6D42D3F</string>
+		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 	</array>
 	<key>NSPrincipalClass</key>
 	<string>Polychromatic</string>


### PR DESCRIPTION
I verified that Polychromatic is in fact compatible with XCode 6.2 (A16FF353-8441-459E-A50C-B071F53F51B7). I pulled the other DVTPlugInCompatibilityUUID from the related issue but I haven't verified if Polychromatic works with 6.3. 